### PR TITLE
Revert "Revert "media: radio: IRIS transport without firmware loading…

### DIFF
--- a/drivers/media/radio/Kconfig
+++ b/drivers/media/radio/Kconfig
@@ -518,6 +518,13 @@ config RADIO_IRIS_TRANSPORT
           To compile this driver as a module, choose M here: the
           module will be called radio-iris-transport.
 
+config RADIO_IRIS_TRANSPORT_NO_FIRMWARE
+        bool "Disable IRIS Transport firmware loading support"
+        depends on RADIO_IRIS_TRANSPORT
+        default n
+        ---help---
+          Say Y here if you want to disable firmware loading support
+
 config RADIO_SILABS
         tristate "SILABS FM"
         depends on I2C && VIDEO_V4L2

--- a/include/uapi/media/radio-iris.h
+++ b/include/uapi/media/radio-iris.h
@@ -183,6 +183,7 @@ struct radio_hci_dev {
 	int (*send)(struct sk_buff *skb);
 	void (*destruct)(struct radio_hci_dev *hdev);
 	void (*notify)(struct radio_hci_dev *hdev, unsigned int evt);
+	void (*close_smd)(void);
 };
 
 int radio_hci_register_dev(struct radio_hci_dev *hdev);


### PR DESCRIPTION
… support""

This reverts commit d5d677e0be61b918307e1dfe331daecb1eb395ba.

Conflicts:
    drivers/media/radio/radio-iris-transport.c

Change-Id: If93d31bd69f12fe9a89c037c2a450892f695fb48

Conflicts:
    drivers/media/radio/radio-iris-transport.c
    drivers/media/radio/radio-iris.c
